### PR TITLE
ammonoid: show volume block stats in status bar

### DIFF
--- a/src/ammonoid/main.c
+++ b/src/ammonoid/main.c
@@ -290,9 +290,15 @@ static void display_pane(unsigned char pane) {
 
 /* Display line on active pane, clear cursor/selection on inactive */
 static void display_active_pane(void) {
+  static unsigned char last_help_pane = 0xff;
   unsigned char inactive_left = pane_left[!active_pane];
 
   display_pane(active_pane);
+
+  if (last_help_pane != active_pane) {
+    last_help_pane = active_pane;
+    help_message();
+  }
 
   set_scrollwindow(0, pane_btm);
   set_hscrollwindow(0, total_width);
@@ -465,9 +471,18 @@ void set_logwindow(void) {
 static void help_message(void) {
     set_logwindow();
     cprintf("Ammonoid - An Apple II file manager.\r\n"
-            "Press H for help - %zuB RAM free",
+            "Press H for help - %zu bytes RAM free",
             _heapmemavail());
 
+    if (pane_directory[active_pane][0] != '\0') {
+      struct statvfs sv;
+      if (statvfs(pane_directory[active_pane], &sv) == 0) {
+        unsigned long total = sv.f_blocks;
+        unsigned long bfree = sv.f_bfree;
+        cprintf("\r\nBlocks free: %lu Blocks used: %lu Total blocks: %lu",
+                bfree, total - bfree, total);
+      }
+    }
 }
 
 static void info_message(const char *msg, unsigned char valid) {


### PR DESCRIPTION
This PR does two things:
1. When viewing a volume, adds a third line in the status bar that displays blocks free, blocks used, and total blocks
2. Made a small wording tweak to the RAM-free line, so the status line now says "12345 bytes RAM free" instead of "12345B RAM free"

For #1, the block stats line only shows when the active pane shows a real directory, not the Devices list (pane_directory[active_pane][0] != '\0').  It refreshes on TAB between panes.

Screenshot is attached here and hope you like my change.
<img width="2330" height="1612" alt="image" src="https://github.com/user-attachments/assets/dc8526da-12c0-4d21-a0c5-88b264e17e73" />
